### PR TITLE
Check If the Email is Already Registered when Registering

### DIFF
--- a/api/Controllers/UsersController.cs
+++ b/api/Controllers/UsersController.cs
@@ -73,6 +73,11 @@ namespace api.Controllers
         public async Task<ActionResult> Create([FromBody] User newUser)
         {
             newUser.Role ??= "User";
+            // Check if email already exists
+            var existingUser = await _service.GetByEmailAsync(newUser.Email);
+            if (existingUser != null)
+                return BadRequest("Email already exists");
+
             // Create user with hashed password
             await _service.CreateAsync(newUser);
 

--- a/frontend/src/components/header.jsx
+++ b/frontend/src/components/header.jsx
@@ -204,6 +204,7 @@ function Header() {
                     px: 3,
                     fontWeight: "bold",
                     fontSize: "1rem",
+                    "&:hover": { backgroundColor: "#ff6f61", color: "white" },
                   }}
                 >
                   Sign Up


### PR DESCRIPTION
This PR fixes the bug where the new user still can use the same email that they have already registered. 